### PR TITLE
Update build instructions to compile correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The project already comes with SDL and SDL_image as submodules
 
 ```
 mkdir build
+cmake -B ./build -G Ninja
 cd build
-cmake -G Ninja
 ninja
 ```
 


### PR DESCRIPTION
The previous instructions did not compile the code correctly. cmake could not find `CMakeLists.txt`.